### PR TITLE
Blank name should default to file

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -21,7 +21,7 @@ class Zaru
   # remove characters that aren't allowed cross-OS
   def sanitize
     @sanitized ||= 
-      filter_windows_reserved_names(normalize.gsub(CHARACTER_FILTER,''))
+      filter(normalize.gsub(CHARACTER_FILTER,''))
   end
 
   # normalize unicode string and cut off at 255 characters
@@ -42,8 +42,17 @@ class Zaru
   
   private
 
+    def filter(filename)
+      filename = filter_windows_reserved_names(filename)
+      filename = filter_blank(filename)
+    end
+
     def filter_windows_reserved_names(filename)
       WINDOWS_RESERVED_NAMES.include?(filename.upcase) ? 'file' : filename
+    end
+
+    def filter_blank(filename)
+      filename == '' ? 'file': filename 
     end
   
 end

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -24,7 +24,7 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal "abcdef", Zaru.sanitize!('abcdef')
     
     %w(< > | / \\ * ? :).each do |char|
-      assert_equal '', Zaru.sanitize!(char)
+      assert_equal 'file', Zaru.sanitize!(char)
       assert_equal 'a', Zaru.sanitize!("a#{char}")
       assert_equal 'a', Zaru.sanitize!("#{char}a")
       assert_equal 'aa', Zaru.sanitize!("a#{char}a")
@@ -43,6 +43,10 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal "file", Zaru.sanitize!(' aux')
     assert_equal "file", Zaru.sanitize!(" LpT\x122")
     assert_equal "COM10", Zaru.sanitize!('COM10')
+  end
+
+  def test_blanks
+    assert_equal "file", Zaru.sanitize!("<")
   end
   
 end


### PR DESCRIPTION
Current solution: "<" becomes "" = Not a legal file name.
New solution: "<" becomes "file" = Legal file name. 
