### PR TITLE
Manage dots

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -45,6 +45,7 @@ class Zaru
     def filter(filename)
       filename = filter_windows_reserved_names(filename)
       filename = filter_blank(filename)
+      filename = filter_dot(filename)
     end
 
     def filter_windows_reserved_names(filename)
@@ -53,6 +54,10 @@ class Zaru
 
     def filter_blank(filename)
       filename == '' ? 'file': filename 
+    end
+
+    def filter_dot(filename)
+      filename.start_with?('.') ? "file#{filename}" : filename
     end
   
 end

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -48,5 +48,10 @@ class ZaruTest < Test::Unit::TestCase
   def test_blanks
     assert_equal "file", Zaru.sanitize!("<")
   end
-  
+
+  def test_dots
+    assert_equal "file.pdf", Zaru.sanitize!(".pdf")
+    assert_equal "file.pdf", Zaru.sanitize!("<.pdf")
+    assert_equal "file..pdf", Zaru.sanitize!("..pdf")
+  end
 end


### PR DESCRIPTION
Filenames cannot start with a dot. I appended 'file' if it starts with a dot.
