### PR TITLE
use fallback filename constant

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -55,7 +55,7 @@ class Zaru
     end
 
     def filter_windows_reserved_names(filename)
-      WINDOWS_RESERVED_NAMES.include?(filename.upcase) ? 'file' : filename
+      WINDOWS_RESERVED_NAMES.include?(filename.upcase) ? FALLBACK_FILENAME : filename
     end
 
     def filter_blank(filename)


### PR DESCRIPTION
Use `FALLBACK_FILENAME` constant rather than typing `"file"` manually.