### PR TITLE
Fixed truncation to take bytesize into account

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -37,7 +37,13 @@ class Zaru
   # optionally provide a padding, which is useful to
   # make sure there is room to add a file extension later
   def truncate
-    @truncated ||= sanitize.chars.to_a.slice(0..254-@padding).join
+    max_size = 255 - @padding
+    size = 0
+
+    @truncated ||= sanitize.chars.take_while do |char|
+      size += char.bytesize
+      size <= max_size
+    end.join
   end
 
   def to_s

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -22,6 +22,14 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal 245, Zaru.sanitize!(name, :padding => 10).length
   end
 
+  def test_truncation_with_unicode_chars
+    name = '–'*400 #  '–' has bytesize 3
+    assert_equal 255, Zaru.sanitize!(name).bytesize
+
+    # less then expected because we can not cut the char in the middle
+    assert_equal 243, Zaru.sanitize!(name, :padding => 10).bytesize
+  end
+
   def test_sanitization
     assert_equal "abcdef", Zaru.sanitize!('abcdef')
 

--- a/zaru.gemspec
+++ b/zaru.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'zaru'
-  s.version     = '0.2.0'
+  s.version     = '0.2.1'
   s.date        = '2017-09-18'
   s.summary     = "Filename sanitization for Ruby"
   s.description = "Zaru takes a given filename (a string) and normalizes, filters and truncates it, so it can be safely used as a filename in modern operating systems. Zaru doesn't remove Unicode characters when not necessary."


### PR DESCRIPTION
Some Unicode characters have more than one char of size (for example '–'). So the size is not calculated correctly in truncation.