### PR TITLE
truncate based on bytesize and not length of string

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -33,11 +33,21 @@ class Zaru
       filter(normalize.gsub(CHARACTER_FILTER,'')).gsub(UNICODE_WHITESPACE,' ')
   end
 
-  # cut off at 255 characters
+  # cut off at 255 bytes
   # optionally provide a padding, which is useful to
   # make sure there is room to add a file extension later
   def truncate
-    @truncated ||= sanitize.chars.to_a.slice(0..254-@padding).join
+    max_size = 255 - @padding
+    @truncated ||= begin
+      return sanitize if sanitize.bytesize < max_size
+
+      result = ''
+      sanitize.each_char do |ch|
+        return result if result.bytesize + ch.bytesize > max_size
+
+        result << ch
+      end
+    end
   end
 
   def to_s

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -20,6 +20,8 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal 255, Zaru.sanitize!(name).length
 
     assert_equal 245, Zaru.sanitize!(name, :padding => 10).length
+
+    assert_equal 255, Zaru.sanitize!("笊"*100).bytesize
   end
 
   def test_sanitization


### PR DESCRIPTION
- The current truncate method is truncating string based on the character length (255 characters). But the limit on most systems is [255 bytes](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits). 
- This cause an error when the name is using different character sets such as chinese/japanese as each character in these languages is 3 bytes.
- Updated logic to ensure the truncated string is 255 bytes in size.