### PR TITLE
Handle Windows reserved names with extensions

### DIFF
--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -63,7 +63,16 @@ class Zaru
   end
 
   def filter_windows_reserved_names(filename)
-    WINDOWS_RESERVED_NAMES.include?(filename.upcase) ? fallback : filename
+    return "" if filename.empty?
+
+    parts = filename.split('.').reject(&:empty?)
+    if WINDOWS_RESERVED_NAMES.include?(parts[0].upcase)
+      parts.slice!(0)
+      parts.unshift(fallback)
+      parts.join('.')
+    else
+      filename
+    end
   end
 
   def filter_blank(filename)

--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -66,6 +66,8 @@ class Zaru
     return "" if filename.empty?
 
     parts = filename.split('.').reject(&:empty?)
+    return "" if parts.empty?
+
     if WINDOWS_RESERVED_NAMES.include?(parts[0].upcase)
       parts.slice!(0)
       parts.unshift(fallback)

--- a/lib/zaru.rb
+++ b/lib/zaru.rb
@@ -63,10 +63,10 @@ class Zaru
   end
 
   def filter_windows_reserved_names(filename)
-    return "" if filename.empty?
+    return '' if filename.empty?
 
     parts = filename.split('.').reject(&:empty?)
-    return "" if parts.empty?
+    return '' if parts.empty?
 
     if WINDOWS_RESERVED_NAMES.include?(parts[0].upcase)
       parts.slice!(0)

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -12,11 +12,25 @@ class ZaruTest < Test::Unit::TestCase
     end
   end
 
+  def test_nil_input
+    assert_equal 'file', Zaru.sanitize!(nil)
+  end
+
+  def test_integer_input
+    assert_equal '42', Zaru.sanitize!(42)
+  end
+
   def test_truncation
     name = 'A' * 400
     assert_equal 255, Zaru.sanitize!(name).length
 
     assert_equal 245, Zaru.sanitize!(name, padding: 10).length
+  end
+
+  def test_padding_boundary_254
+    result = Zaru.sanitize!('A' * 1000, padding: 254)
+    assert_equal 1, result.length
+    assert_operator result.length, :<=, 255
   end
 
   def test_truncation_with_large_padding
@@ -46,6 +60,10 @@ class ZaruTest < Test::Unit::TestCase
 
     assert_equal 'whatēverwëirduserînput',
                  Zaru.sanitize!('  what\\ēver//wëird:user:înput:')
+  end
+
+  def test_special_unicode_chars_filtered
+    assert_equal 'yo', Zaru.sanitize!("yo\x00")
   end
 
   def test_windows_reserved_names
@@ -97,4 +115,11 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal 'blub', Zaru.sanitize!('lpt1', fallback: 'blub')
     assert_equal 'blub.pdf', Zaru.sanitize!('<.pdf', fallback: 'blub')
   end
+
+  def test_punctuation_only_with_custom_fallback
+    assert_equal 'custom', Zaru.sanitize!('...', fallback: 'custom')
+    assert_equal 'custom', Zaru.sanitize!('<<>>', fallback: 'custom')
+  end
+
+
 end

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -27,7 +27,7 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal 245, Zaru.sanitize!(name, padding: 10).length
   end
 
-  def test_padding_boundary_254
+  def test_padding_exact_boundary
     result = Zaru.sanitize!('A' * 1000, padding: 254)
     assert_equal 1, result.length
     assert_operator result.length, :<=, 255
@@ -120,6 +120,4 @@ class ZaruTest < Test::Unit::TestCase
     assert_equal 'custom', Zaru.sanitize!('...', fallback: 'custom')
     assert_equal 'custom', Zaru.sanitize!('<<>>', fallback: 'custom')
   end
-
-
 end

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -62,9 +62,16 @@ class ZaruTest < Test::Unit::TestCase
   end
 
   def test_windows_reserved_names_with_extensions
-    assert_equal 'con.ext', Zaru.sanitize!('con.ext')
-    assert_equal 'file.con', Zaru.sanitize!('file.con')
+    # Microsoft's documentation states that "avoid these names followed
+    # immediately by an extension; for example, NUL.txt and NUL.tar.gz
+    # are both equivalent to NUL
+    assert_equal 'file.txt', Zaru.sanitize!('nul.ext')
+    assert_equal 'file.tar.gz', Zaru.sanitize!('nul.tar.gz')
+    assert_equal 'file.tar.gz', Zaru.sanitize!(' COM³.tar.gz ')
 
+    # it's fine if reserved names are used as extensions
+    # or as part of filenames
+    assert_equal 'file.con', Zaru.sanitize!('file.con')
     assert_equal 'Acon.ext', Zaru.sanitize!('Acon.ext')
     assert_equal 'Afile.con', Zaru.sanitize!('Afile.con')
   end

--- a/test/test_zaru.rb
+++ b/test/test_zaru.rb
@@ -65,7 +65,8 @@ class ZaruTest < Test::Unit::TestCase
     # Microsoft's documentation states that "avoid these names followed
     # immediately by an extension; for example, NUL.txt and NUL.tar.gz
     # are both equivalent to NUL
-    assert_equal 'file.txt', Zaru.sanitize!('nul.ext')
+    assert_equal 'file.txt', Zaru.sanitize!('nul.txt')
+    assert_equal 'file.txt', Zaru.sanitize!('.nul.txt')
     assert_equal 'file.tar.gz', Zaru.sanitize!('nul.tar.gz')
     assert_equal 'file.tar.gz', Zaru.sanitize!(' COM³.tar.gz ')
 


### PR DESCRIPTION
Microsoft's [documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file) says to _avoid these [Windows reserved names like CON or NUL] names followed immediately by an extension; for example, NUL.txt and NUL.tar.gz are both equivalent to NUL_.

This PR adds support for avoiding filename/extension combinations like these.